### PR TITLE
show the xp bar even when the chatbox is hidden

### DIFF
--- a/src/main/java/com/maplexpbar/MapleXPBarPlugin.java
+++ b/src/main/java/com/maplexpbar/MapleXPBarPlugin.java
@@ -3,6 +3,7 @@ package com.maplexpbar;
 import com.google.inject.Provides;
 import javax.inject.Inject;
 
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -154,7 +155,7 @@ class XPBarOverlay extends Overlay
 		for (Viewport viewport : Viewport.values())
 		{
 			final Widget viewportWidget = client.getWidget(viewport.getViewport());
-			if (viewportWidget != null && !viewportWidget.isHidden())
+			if (viewportWidget != null)
 			{
 				curViewport = viewport;
 				curWidget = viewportWidget;
@@ -167,13 +168,16 @@ class XPBarOverlay extends Overlay
 			return null;
 		}
 
+		boolean isChatboxUnloaded = curWidget.getCanvasLocation().equals(new Point(-1, -1));
+
 		final Point offset = curViewport.getOffsetLeft();
-		final Point location = curWidget.getCanvasLocation();
+		final Point location = isChatboxUnloaded ? new Point(0, client.getCanvasHeight() - 165) : curWidget.getCanvasLocation();
 		final int height, offsetBarX, offsetBarY;
 
+		int chatboxHiddenOffset = curWidget.isHidden() ? 142 : 0;
 		height = HEIGHT;
 		offsetBarX = (location.getX() - offset.getX());
-		offsetBarY = (location.getY() - offset.getY());
+		offsetBarY = (location.getY() - offset.getY() + chatboxHiddenOffset);
 
 		if (config.displayHealthAndPrayer())
 			renderThreeBars(g, offsetBarX, offsetBarY, height);


### PR DESCRIPTION
fixes #8 

When the chatbox is hidden, the xp bar also goes away because it's location is tied to the top of it. Now, show the xp bar even while the chatbox is hidden and unloaded (when it's unloaded, can't get the coords) by guessing based on the client window size.