### PR TITLE
Add 3 skill tracking mode, organize configs

### DIFF
--- a/src/main/java/com/maplexpbar/MapleXPBarConfig.java
+++ b/src/main/java/com/maplexpbar/MapleXPBarConfig.java
@@ -103,25 +103,16 @@ public interface MapleXPBarConfig extends Config
 
 	@ConfigItem(
 			position = 1,
-			keyName = "showPercentage",
-			name = "Show XP Percentage",
+			keyName = "tooltipMode",
+			name = "Tooltip Text",
 			section = advancedSection,
-			description = "Also shows XP percentage when hovering over bar"
+			description = "Display the current over total XP, XP as a percent to next level, or both"
 	)
-	default boolean showPercentage() { return true; }
-
-	@ConfigItem(
-			position = 2,
-			keyName = "showOnlyPercentage",
-			name = "Only show Percentage",
-			section = advancedSection,
-			description = "When showing percentage, hide the current XP/next level XP"
-	)
-	default boolean showOnlyPercentage() { return false; }
+	default MapleXPBarTooltipMode tooltipMode() { return MapleXPBarTooltipMode.BOTH; }
 
 	@Alpha
 	@ConfigItem(
-			position = 3,
+			position = 2,
 			keyName = "xpbarColor",
 			name = "XP Progress Bar Color",
 			section = advancedSection,
@@ -134,7 +125,7 @@ public interface MapleXPBarConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-			position = 4,
+			position = 3,
 			keyName = "xpbarNotchColor",
 			name = "XP Notch Color",
 			section = advancedSection,
@@ -147,7 +138,7 @@ public interface MapleXPBarConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-			position = 5,
+			position = 4,
 			keyName = "xpbarTextColor",
 			name = "XP Text Color",
 			section = advancedSection,
@@ -160,20 +151,20 @@ public interface MapleXPBarConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-			position = 6,
+			position = 5,
 			keyName = "xpbarSkillColor",
-			name = "XP Progressbar as skill color",
+			name = "Automatically Pick Skill Color",
 			section = advancedSection,
-			description = "Configure the latest skill color as the XP bar color"
+			description = "Use the skill's color instead of the user set color"
 	)
-	default boolean mostRecentSkillColor() { return false; }
+	default boolean shouldAutoPickSkillColor() { return false; }
 
 	@ConfigItem(
-			position = 7,
+			position = 6,
 			keyName = "barMode",
 			name = "Bar Mode",
 			section = advancedSection,
-			description = "Single: only displays the XP bar<br>Health and Prayer: display current HP and Pray above the XP bar<br>Multi Skill: Display XP bars for up to 3 skills at once"
+			description = "Single: only displays the XP bar<br>Health and Prayer: display current HP and Pray above the XP bar<br>Multi Skill: Display XP bars for 3 skills at once"
 	)
 	default MapleXPBarMode barMode() { return MapleXPBarMode.SINGLE; }
 
@@ -225,6 +216,102 @@ public interface MapleXPBarConfig extends Config
 			description = "Configures the color of the Prayer bar notches"
 	)
 	default Color colorPrayNotches()
+	{
+		return Color.DARK_GRAY;
+	}
+
+	@ConfigItem(
+			position = 0,
+			keyName = "skill2",
+			name = "Skill 2",
+			section = multiSkillModeSection,
+			description = "Choose which skill to show xp for on the second bar"
+	)
+	default Skill skill2()
+	{
+		return Skill.STRENGTH;
+	}
+
+	@Alpha
+	@ConfigItem(
+			position = 1,
+			keyName = "xpbarSkill2Color",
+			name = "Automatically Pick Skill 2 Color",
+			section = multiSkillModeSection,
+			description = "Use the skill's color instead of the user set color"
+	)
+	default boolean shouldAutoPickSkill2Color() { return true; }
+
+	@Alpha
+	@ConfigItem(
+			position = 2,
+			keyName = "skill2barColor",
+			name = "Skill 2 Bar Color",
+			section = multiSkillModeSection,
+			description = "Configures the color of the second skill bar"
+	)
+	default Color colorSkill2()
+	{
+		return Color.ORANGE;
+	}
+
+	@Alpha
+	@ConfigItem(
+			position = 3,
+			keyName = "skill2barNotchColor",
+			name = "Skill 2 Notch Color",
+			section = multiSkillModeSection,
+			description = "Configures the color of the second skill bar notches"
+	)
+	default Color colorSkill2Notches()
+	{
+		return Color.DARK_GRAY;
+	}
+
+	@ConfigItem(
+			position = 4,
+			keyName = "skill3",
+			name = "Skill 3",
+			section = multiSkillModeSection,
+			description = "Choose which skill to show xp for on the third bar"
+	)
+	default Skill skill3()
+	{
+		return Skill.DEFENCE;
+	}
+
+	@Alpha
+	@ConfigItem(
+			position = 5,
+			keyName = "xpbarSkill3Color",
+			name = "Automatically Pick Skill 3 Color",
+			section = multiSkillModeSection,
+			description = "Use the skill's color instead of the user set color"
+	)
+	default boolean shouldAutoPickSkill3Color() { return true; }
+
+	@Alpha
+	@ConfigItem(
+			position = 6,
+			keyName = "skill3barColor",
+			name = "Skill 3 Bar Color",
+			section = multiSkillModeSection,
+			description = "Configures the color of the third skill bar"
+	)
+	default Color colorSkill3()
+	{
+		return Color.PINK;
+	}
+
+	@Alpha
+	@ConfigItem(
+			position = 7,
+			keyName = "skill3barNotchColor",
+			name = "Skill 3 Notch Color",
+			section = multiSkillModeSection,
+			description = "Configures the color of the third skill bar notches"
+	)
+	default Color colorSkill3Notches()
 	{
 		return Color.DARK_GRAY;
 	}

--- a/src/main/java/com/maplexpbar/MapleXPBarConfig.java
+++ b/src/main/java/com/maplexpbar/MapleXPBarConfig.java
@@ -23,9 +23,23 @@ public interface MapleXPBarConfig extends Config
 	String advancedSection = "advanced";
 
 	@ConfigSection(
+			name = "Health and Prayer Mode",
+			description = "Configure the look of the bars when in Health and Prayer mode",
+			position = 2
+	)
+	String healthAndPrayerSection = "healthAndPrayerMode";
+
+	@ConfigSection(
+			name = "Multi Skill Mode",
+			description = "Configure the look of the bars when in Multi Skill mode",
+			position = 3
+	)
+	String multiSkillModeSection = "multiSkillMode";
+
+	@ConfigSection(
 			name = "Bar Position and Sizing",
 			description = "Options to reposition and resize the experience bar",
-			position = 2
+			position = 4
 	)
 	String positionSizingSection = "positionAndSizing";
 
@@ -79,15 +93,6 @@ public interface MapleXPBarConfig extends Config
 	default int maxedThreshold() { return 13034431; }
 
 	@ConfigItem(
-			position = 5,
-			keyName = "displayHealthAndPrayer",
-			name = "Display Health And Prayer",
-			section = generalSection,
-			description = "Also shows a health and prayer bar"
-	)
-	default boolean displayHealthAndPrayer() { return false; }
-
-	@ConfigItem(
 			position = 0,
 			keyName = "alwaysShowTooltip",
 			name = "Always Display Tooltip",
@@ -117,58 +122,6 @@ public interface MapleXPBarConfig extends Config
 	@Alpha
 	@ConfigItem(
 			position = 3,
-			keyName = "hpbarColor",
-			name = "HP Bar Color",
-			section = advancedSection,
-			description = "Configures the color of the HP bar"
-	)
-	default Color colorHP()
-	{
-		return Color.RED;
-	}
-
-	@Alpha
-	@ConfigItem(
-			position = 4,
-			keyName = "hpbarNotchColor",
-			name = "HP Notch Color",
-			section = advancedSection,
-			description = "Configures the color of the HP bar notches"
-	)
-	default Color colorHPNotches()
-	{
-		return Color.LIGHT_GRAY;
-	}
-
-	@Alpha
-	@ConfigItem(
-			position = 5,
-			keyName = "praybarColor",
-			name = "Prayer Bar Color",
-			section = advancedSection,
-			description = "Configures the color of the Prayer bar"
-	)
-	default Color colorPray()
-	{
-		return Color.CYAN;
-	}
-
-	@Alpha
-	@ConfigItem(
-			position = 6,
-			keyName = "praybarNotchColor",
-			name = "Prayer Notch Color",
-			section = advancedSection,
-			description = "Configures the color of the Prayer bar notches"
-	)
-	default Color colorPrayNotches()
-	{
-		return Color.DARK_GRAY;
-	}
-
-	@Alpha
-	@ConfigItem(
-			position = 7,
 			keyName = "xpbarColor",
 			name = "XP Progress Bar Color",
 			section = advancedSection,
@@ -181,7 +134,7 @@ public interface MapleXPBarConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-			position = 8,
+			position = 4,
 			keyName = "xpbarNotchColor",
 			name = "XP Notch Color",
 			section = advancedSection,
@@ -194,7 +147,7 @@ public interface MapleXPBarConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-			position = 9,
+			position = 5,
 			keyName = "xpbarTextColor",
 			name = "XP Text Color",
 			section = advancedSection,
@@ -207,13 +160,74 @@ public interface MapleXPBarConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-			position = 10,
+			position = 6,
 			keyName = "xpbarSkillColor",
 			name = "XP Progressbar as skill color",
 			section = advancedSection,
 			description = "Configure the latest skill color as the XP bar color"
 	)
 	default boolean mostRecentSkillColor() { return false; }
+
+	@ConfigItem(
+			position = 7,
+			keyName = "barMode",
+			name = "Bar Mode",
+			section = advancedSection,
+			description = "Single: only displays the XP bar<br>Health and Prayer: display current HP and Pray above the XP bar<br>Multi Skill: Display XP bars for up to 3 skills at once"
+	)
+	default MapleXPBarMode barMode() { return MapleXPBarMode.SINGLE; }
+
+	@Alpha
+	@ConfigItem(
+			position = 0,
+			keyName = "hpbarColor",
+			name = "HP Bar Color",
+			section = healthAndPrayerSection,
+			description = "Configures the color of the HP bar"
+	)
+	default Color colorHP()
+	{
+		return Color.RED;
+	}
+
+	@Alpha
+	@ConfigItem(
+			position = 1,
+			keyName = "hpbarNotchColor",
+			name = "HP Notch Color",
+			section = healthAndPrayerSection,
+			description = "Configures the color of the HP bar notches"
+	)
+	default Color colorHPNotches()
+	{
+		return Color.LIGHT_GRAY;
+	}
+
+	@Alpha
+	@ConfigItem(
+			position = 2,
+			keyName = "praybarColor",
+			name = "Prayer Bar Color",
+			section = healthAndPrayerSection,
+			description = "Configures the color of the Prayer bar"
+	)
+	default Color colorPray()
+	{
+		return Color.CYAN;
+	}
+
+	@Alpha
+	@ConfigItem(
+			position = 3,
+			keyName = "praybarNotchColor",
+			name = "Prayer Notch Color",
+			section = healthAndPrayerSection,
+			description = "Configures the color of the Prayer bar notches"
+	)
+	default Color colorPrayNotches()
+	{
+		return Color.DARK_GRAY;
+	}
 
 	@ConfigItem(
 			position = 0,

--- a/src/main/java/com/maplexpbar/MapleXPBarMode.java
+++ b/src/main/java/com/maplexpbar/MapleXPBarMode.java
@@ -1,0 +1,23 @@
+package com.maplexpbar;
+
+import lombok.Getter;
+
+@Getter
+public enum MapleXPBarMode {
+    SINGLE("Single Bar"),
+    HEALTH_AND_PRAYER("Health and Prayer"),
+    MULTI_SKILL("Multi Skill");
+
+    private final String menuName;
+
+    MapleXPBarMode(String menuName)
+    {
+        this.menuName = menuName;
+    }
+
+    @Override
+    public String toString()
+    {
+        return menuName;
+    }
+}

--- a/src/main/java/com/maplexpbar/MapleXPBarPlugin.java
+++ b/src/main/java/com/maplexpbar/MapleXPBarPlugin.java
@@ -320,7 +320,7 @@ class XPBarOverlay extends Overlay
 
 		String xpText = getTootltipText(currentXP, currentLevelXP, nextLevelXP);
 
-		boolean	hoveringBar = client.getMouseCanvasPosition().getX() >= adjustedX && client.getMouseCanvasPosition().getY() >= adjustedY
+		boolean	hoveringBar = client.getMouseCanvasPosition().getX() >= adjustedX && client.getMouseCanvasPosition().getY() > adjustedY
 				&& client.getMouseCanvasPosition().getX() <= adjustedX + adjustedWidth && client.getMouseCanvasPosition().getY() <= adjustedY + height;
 
 		if (hoveringBar || config.alwaysShowTooltip())
@@ -376,6 +376,21 @@ class XPBarOverlay extends Overlay
 
 			drawBar(graphics, adjustedX, adjustedY- height, adjustedWidth, filledWidthXP2, bar2Color, config.colorSkill2Notches());
 			drawBar(graphics, adjustedX, adjustedY-(height *2), adjustedWidth, filledWidthXP3, bar3Color, config.colorSkill3Notches());
+
+			String tooltip = "";
+			boolean	hoveringBar2 = client.getMouseCanvasPosition().getX() >= adjustedX && client.getMouseCanvasPosition().getY() > adjustedY - height
+					&& client.getMouseCanvasPosition().getX() <= adjustedX + adjustedWidth && client.getMouseCanvasPosition().getY() <= adjustedY;
+			if (hoveringBar2) { tooltip = getTootltipText(currentXP2, currentLevelXP2, nextLevelXP2); }
+			boolean	hoveringBar3 = client.getMouseCanvasPosition().getX() >= adjustedX && client.getMouseCanvasPosition().getY() > adjustedY - (height * 2)
+					&& client.getMouseCanvasPosition().getX() <= adjustedX + adjustedWidth && client.getMouseCanvasPosition().getY() <= adjustedY - height;
+			if (hoveringBar3) { tooltip = getTootltipText(currentXP3, currentLevelXP3, nextLevelXP3); }
+
+			// if we're always showing tooltip text for bar 1, we can't show tooltips for either of the other bars
+			if (!config.alwaysShowTooltip() && (hoveringBar2 || hoveringBar3)) {
+				graphics.setColor(config.colorXPText());
+				graphics.setFont(plugin.getFont());
+				graphics.drawString(tooltip, adjustedX + (adjustedWidth/2 + 8) - (tooltip.length()*3), adjustedY-(height *2));
+			}
 		}
 	}
 

--- a/src/main/java/com/maplexpbar/MapleXPBarTooltipMode.java
+++ b/src/main/java/com/maplexpbar/MapleXPBarTooltipMode.java
@@ -1,0 +1,23 @@
+package com.maplexpbar;
+
+import lombok.Getter;
+
+@Getter
+public enum MapleXPBarTooltipMode {
+    CURRENT_XP("Current XP"),
+    PERCENTAGE("Percentage"),
+    BOTH("Both");
+
+    private final String menuName;
+
+    MapleXPBarTooltipMode(String menuName)
+    {
+        this.menuName = menuName;
+    }
+
+    @Override
+    public String toString()
+    {
+        return menuName;
+    }
+}


### PR DESCRIPTION
## Description
Adds a way to track 3 different skills at once
Re-organize the new and existing configs into categories

## Screenshots
Tracking Attack, Strength, and Defence with Multi-Skill mode
![image](https://github.com/user-attachments/assets/90041980-49a7-4991-ac7a-894951f40bad)

New config layout
![image](https://github.com/user-attachments/assets/8e1c1f19-7d81-4eb5-bc76-1e3f02ed14f8)