### PR TITLE
Allow user to configure the background color of the bars

### DIFF
--- a/src/main/java/com/maplexpbar/MapleXPBarConfig.java
+++ b/src/main/java/com/maplexpbar/MapleXPBarConfig.java
@@ -114,9 +114,9 @@ public interface MapleXPBarConfig extends Config
 	@ConfigItem(
 			position = 2,
 			keyName = "xpbarColor",
-			name = "XP Progress Bar Color",
+			name = "XP Progress Color",
 			section = advancedSection,
-			description = "Configures the color of the XP bar"
+			description = "Configures the progress color of the XP bar"
 	)
 	default Color colorXP()
 	{
@@ -139,6 +139,19 @@ public interface MapleXPBarConfig extends Config
 	@Alpha
 	@ConfigItem(
 			position = 4,
+			keyName = "xpbarBackgroundColor",
+			name = "XP Bar Background",
+			section = advancedSection,
+			description = "Configures the background color of the XP bar"
+	)
+	default Color colorXPBackground()
+	{
+		return Color.BLACK;
+	}
+
+	@Alpha
+	@ConfigItem(
+			position = 5,
 			keyName = "xpbarTextColor",
 			name = "XP Text Color",
 			section = advancedSection,
@@ -151,7 +164,7 @@ public interface MapleXPBarConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-			position = 5,
+			position = 6,
 			keyName = "xpbarSkillColor",
 			name = "Automatically Pick Skill Color",
 			section = advancedSection,
@@ -160,7 +173,7 @@ public interface MapleXPBarConfig extends Config
 	default boolean shouldAutoPickSkillColor() { return false; }
 
 	@ConfigItem(
-			position = 6,
+			position = 7,
 			keyName = "barMode",
 			name = "Bar Mode",
 			section = advancedSection,
@@ -197,6 +210,19 @@ public interface MapleXPBarConfig extends Config
 	@Alpha
 	@ConfigItem(
 			position = 2,
+			keyName = "hpbarBackgroundColor",
+			name = "HP Bar Background",
+			section = healthAndPrayerSection,
+			description = "Configures the background color of the HP bar"
+	)
+	default Color colorHPBackground()
+	{
+		return Color.BLACK;
+	}
+
+	@Alpha
+	@ConfigItem(
+			position = 3,
 			keyName = "praybarColor",
 			name = "Prayer Bar Color",
 			section = healthAndPrayerSection,
@@ -209,7 +235,7 @@ public interface MapleXPBarConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-			position = 3,
+			position = 4,
 			keyName = "praybarNotchColor",
 			name = "Prayer Notch Color",
 			section = healthAndPrayerSection,
@@ -218,6 +244,19 @@ public interface MapleXPBarConfig extends Config
 	default Color colorPrayNotches()
 	{
 		return Color.DARK_GRAY;
+	}
+
+	@Alpha
+	@ConfigItem(
+			position = 5,
+			keyName = "praybarBackgroundColor",
+			name = "Prayer Bar Background",
+			section = healthAndPrayerSection,
+			description = "Configures the background color of the Prayer bar"
+	)
+	default Color colorPrayBackground()
+	{
+		return Color.BLACK;
 	}
 
 	@ConfigItem(
@@ -246,7 +285,7 @@ public interface MapleXPBarConfig extends Config
 	@ConfigItem(
 			position = 2,
 			keyName = "skill2barColor",
-			name = "Skill 2 Bar Color",
+			name = "Skill 2 Progress Color",
 			section = multiSkillModeSection,
 			description = "Configures the color of the second skill bar"
 	)
@@ -268,8 +307,21 @@ public interface MapleXPBarConfig extends Config
 		return Color.DARK_GRAY;
 	}
 
+	@Alpha
 	@ConfigItem(
 			position = 4,
+			keyName = "skill2barBackgroundColor",
+			name = "Skill 2 Background",
+			section = multiSkillModeSection,
+			description = "Configures the color of the second skill bar background"
+	)
+	default Color colorSkill2Background()
+	{
+		return Color.BLACK;
+	}
+
+	@ConfigItem(
+			position = 5,
 			keyName = "skill3",
 			name = "Skill 3",
 			section = multiSkillModeSection,
@@ -282,7 +334,7 @@ public interface MapleXPBarConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-			position = 5,
+			position = 6,
 			keyName = "xpbarSkill3Color",
 			name = "Automatically Pick Skill 3 Color",
 			section = multiSkillModeSection,
@@ -292,9 +344,9 @@ public interface MapleXPBarConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-			position = 6,
+			position = 7,
 			keyName = "skill3barColor",
-			name = "Skill 3 Bar Color",
+			name = "Skill 3 Progress Color",
 			section = multiSkillModeSection,
 			description = "Configures the color of the third skill bar"
 	)
@@ -305,7 +357,20 @@ public interface MapleXPBarConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-			position = 7,
+			position = 8,
+			keyName = "skill3barBackgroundColor",
+			name = "Skill 3 Background",
+			section = multiSkillModeSection,
+			description = "Configures the color of the third skill bar background"
+	)
+	default Color colorSkill3Background()
+	{
+		return Color.BLACK;
+	}
+
+	@Alpha
+	@ConfigItem(
+			position = 8,
 			keyName = "skill3barNotchColor",
 			name = "Skill 3 Notch Color",
 			section = multiSkillModeSection,

--- a/src/main/java/com/maplexpbar/MapleXPBarPlugin.java
+++ b/src/main/java/com/maplexpbar/MapleXPBarPlugin.java
@@ -175,7 +175,6 @@ class XPBarOverlay extends Overlay
 	private MapleXPBarConfig config;
 	private Client client;
 	private static final Logger logger = LoggerFactory.getLogger(XPBarOverlay.class);
-	private static final Color BACKGROUND = new Color(0, 0, 0, 255);
 	static int HEIGHT = 4;
 	private static final int BORDER_SIZE = 1;
 
@@ -352,11 +351,11 @@ class XPBarOverlay extends Overlay
 			barColor = config.colorXP();
 		}
 
-		drawBar(graphics, adjustedX, adjustedY, adjustedWidth, filledWidthXP, barColor, config.colorXPNotches());
+		drawBar(graphics, adjustedX, adjustedY, adjustedWidth, filledWidthXP, barColor, config.colorXPNotches(), config.colorXPBackground());
 
 		if (mode.equals(MapleXPBarMode.HEALTH_AND_PRAYER)){
-			drawBar(graphics, adjustedX, adjustedY- height, adjustedWidth, filledWidthPray, config.colorPray(), config.colorPrayNotches());
-			drawBar(graphics, adjustedX, adjustedY-(height *2), adjustedWidth, filledWidthHP, config.colorHP(), config.colorHPNotches());
+			drawBar(graphics, adjustedX, adjustedY- height, adjustedWidth, filledWidthPray, config.colorPray(), config.colorPrayNotches(), config.colorPrayBackground());
+			drawBar(graphics, adjustedX, adjustedY-(height *2), adjustedWidth, filledWidthHP, config.colorHP(), config.colorHPNotches(), config.colorHPBackground());
 		}
 		else if (mode.equals(MapleXPBarMode.MULTI_SKILL))
 		{
@@ -374,8 +373,8 @@ class XPBarOverlay extends Overlay
 			int filledWidthXP3 = getBarWidth(nextLevelXP3 - currentLevelXP3, currentXP3 - currentLevelXP3, adjustedWidth);
 			Color bar3Color = config.shouldAutoPickSkill3Color() ? SkillColor.find(config.skill3()).getColor() : config.colorSkill3();
 
-			drawBar(graphics, adjustedX, adjustedY- height, adjustedWidth, filledWidthXP2, bar2Color, config.colorSkill2Notches());
-			drawBar(graphics, adjustedX, adjustedY-(height *2), adjustedWidth, filledWidthXP3, bar3Color, config.colorSkill3Notches());
+			drawBar(graphics, adjustedX, adjustedY- height, adjustedWidth, filledWidthXP2, bar2Color, config.colorSkill2Notches(), config.colorSkill2Background());
+			drawBar(graphics, adjustedX, adjustedY-(height *2), adjustedWidth, filledWidthXP3, bar3Color, config.colorSkill3Notches(), config.colorSkill3Background());
 
 			String tooltip = "";
 			boolean	hoveringBar2 = client.getMouseCanvasPosition().getX() >= adjustedX && client.getMouseCanvasPosition().getY() > adjustedY - height
@@ -394,11 +393,11 @@ class XPBarOverlay extends Overlay
 		}
 	}
 
-	private void drawBar(Graphics2D graphics, int adjustedX, int adjustedY, int adjustedWidth, int fill, Color barColor, Color notchColor)
+	private void drawBar(Graphics2D graphics, int adjustedX, int adjustedY, int adjustedWidth, int fill, Color barColor, Color notchColor, Color backgroundColor)
 	{
 		int height = config.thickness();
 
-		graphics.setColor(BACKGROUND);
+		graphics.setColor(backgroundColor);
 		graphics.drawRect(adjustedX, adjustedY, adjustedWidth - BORDER_SIZE, height - BORDER_SIZE);
 		graphics.fillRect(adjustedX, adjustedY, adjustedWidth, height);
 


### PR DESCRIPTION
Allows the user to configure the background colors of the various bars.

(example shown has configured the background to white)
![image](https://github.com/user-attachments/assets/45697e9a-7dbb-4313-aa2f-83d0cadf1bef)
