### PR TITLE
New anchor points - minimap and inventory

### DIFF
--- a/src/main/java/com/maplexpbar/MapleXPBarAnchorMode.java
+++ b/src/main/java/com/maplexpbar/MapleXPBarAnchorMode.java
@@ -1,0 +1,24 @@
+package com.maplexpbar;
+
+import lombok.Getter;
+
+@Getter
+public enum MapleXPBarAnchorMode {
+    CHATBOX("Chatbox"),
+    TOP_LEFT("Top Left"),
+    MINIMAP("Minimap"),
+    INVENTORY("Inventory");
+
+    private final String menuName;
+
+    MapleXPBarAnchorMode(String menuName)
+    {
+        this.menuName = menuName;
+    }
+
+    @Override
+    public String toString()
+    {
+        return menuName;
+    }
+}

--- a/src/main/java/com/maplexpbar/MapleXPBarConfig.java
+++ b/src/main/java/com/maplexpbar/MapleXPBarConfig.java
@@ -386,7 +386,7 @@ public interface MapleXPBarConfig extends Config
 			keyName = "anchorPoint",
 			name = "Anchor Point",
 			section = positionSizingSection,
-			description = "what UI piece the offset values are in reference to. Minimap and Inventory are only available in Resizable layouts"
+			description = "Which UI piece the offset values are in reference to"
 	)
 	default MapleXPBarAnchorMode anchorPoint() { return MapleXPBarAnchorMode.CHATBOX; }
 

--- a/src/main/java/com/maplexpbar/MapleXPBarConfig.java
+++ b/src/main/java/com/maplexpbar/MapleXPBarConfig.java
@@ -383,12 +383,12 @@ public interface MapleXPBarConfig extends Config
 
 	@ConfigItem(
 			position = 0,
-			keyName = "anchorToChatbox",
-			name = "Anchor to Chatbox",
+			keyName = "anchorPoint",
+			name = "Anchor Point",
 			section = positionSizingSection,
-			description = "When enabled, the offset values are in reference to top of the chatbox. When off, they are in reference to the top-left of the client"
+			description = "what UI piece the offset values are in reference to. Minimap and Inventory are only available in Resizable layouts"
 	)
-	default boolean anchorToChatbox() { return true; }
+	default MapleXPBarAnchorMode anchorPoint() { return MapleXPBarAnchorMode.CHATBOX; }
 
 	@Range(min=-9999, max=9999)
 	@ConfigItem(

--- a/src/main/java/com/maplexpbar/MapleXPBarPlugin.java
+++ b/src/main/java/com/maplexpbar/MapleXPBarPlugin.java
@@ -166,6 +166,14 @@ public class MapleXPBarPlugin extends Plugin
 			configManager.unsetConfiguration("MapleXP", "showPercentage");
 			configManager.unsetConfiguration("MapleXP", "showOnlyPercentage");
 		}
+
+		// old anchor to chatbox migration
+		Boolean oldAnchorToChatbox = configManager.getConfiguration("MapleXP", "anchorToChatbox", Boolean.class);
+		if (oldAnchorToChatbox != null){
+			// convert legacy setting to new one
+			configManager.setConfiguration("MapleXP", "anchorPoint", oldAnchorToChatbox ? MapleXPBarAnchorMode.CHATBOX : MapleXPBarAnchorMode.TOP_LEFT);
+		}
+		configManager.unsetConfiguration("MapleXP", "anchorToChatbox");
 	}
 }
 
@@ -231,7 +239,7 @@ class XPBarOverlay extends Overlay
 		final Point location = isChatboxUnloaded ? new Point(0, client.getCanvasHeight() - 165) : curWidget.getCanvasLocation();
 		final int height, offsetBarX, offsetBarY;
 
-		boolean automaticallyOffsetBar = config.anchorToChatbox();
+		boolean automaticallyOffsetBar = config.anchorPoint() == MapleXPBarAnchorMode.CHATBOX;
 
 		int chatboxHiddenOffset = curWidget.isHidden() && automaticallyOffsetBar ? 142 : 0;
 		height = config.thickness();
@@ -306,7 +314,7 @@ class XPBarOverlay extends Overlay
 			}
 		}
 
-		boolean automaticallyOffsetBar = config.anchorToChatbox();
+		boolean automaticallyOffsetBar = config.anchorPoint() == MapleXPBarAnchorMode.CHATBOX;
 
 		adjustedY = client.isResized() && isTransparentChatbox && isChatShown && automaticallyOffsetBar? y + 7: y;
 


### PR DESCRIPTION
Add extra anchor points to the config to further customize the location of the bar.

Old behavior - screen resizing can "dislodge" the xp bar

https://github.com/user-attachments/assets/280780d9-c51e-407b-8121-2fe955341db4


New behavior - bar sticks to the minimap during resizing and relocating of the minimap


https://github.com/user-attachments/assets/21541a77-d620-45e0-9a64-c50ad59cfa9a


Related issues:
#28 
